### PR TITLE
neutralize bringup dependencies

### DIFF
--- a/cob_bringup_test/package.xml
+++ b/cob_bringup_test/package.xml
@@ -15,7 +15,8 @@
  
   <build_depend>roslaunch</build_depend>
  
-  <run_depend>cob_bringup</run_depend>
+  <!--run_depend>cob_bringup</run_depend--> <!-- not declare dependency - simplifies travis ci -->
+  <!--run_depend>cob_bringup_sim</run_depend--> <!-- not declare dependency - simplifies travis ci -->
   <run_depend>cob_hardware_test_core</run_depend>
 
 

--- a/cob_test_rigs/launch/arm_pg70.launch
+++ b/cob_test_rigs/launch/arm_pg70.launch
@@ -24,7 +24,7 @@
 		<param name="robot_description" command="$(find xacro)/xacro --inorder '$(arg pkg_hardware_config)/robots/$(arg robot)/urdf/$(arg robot).urdf.xacro'"/>
 
 		<!-- arm component -->
-		<include file="$(find cob_bringup)/drivers/canopen_402.launch">
+		<include file="$(find cob_test_rigs)/launch/drivers/canopen_402.launch">
 			<arg name="robot" value="arm"/>
 			<arg name="pkg_hardware_config" value="$(arg pkg_hardware_config)"/>
 			<arg name="component_name" value="arm"/>
@@ -34,14 +34,14 @@
 			<arg name="start_external_sync" value="true"/>
 		</include>
 
-		<include file="$(find cob_bringup)/controllers/generic_controller.launch">
+		<include file="$(find cob_test_rigs)/launch/controllers/generic_controller.launch">
 			<arg name="robot" value="arm"/>
 			<arg name="pkg_hardware_config" value="$(arg pkg_hardware_config)"/>
 			<arg name="component_name" value="arm"/>
 		</include>
 
 		<!-- pg70 component -->
-		<include file="$(find cob_bringup)/drivers/canopen_402.launch">
+		<include file="$(find cob_test_rigs)/launch/drivers/canopen_402.launch">
 			<arg name="robot" value="pg70"/>
 			<arg name="pkg_hardware_config" value="$(arg pkg_hardware_config)"/>
 			<arg name="component_name" value="pg70"/>
@@ -51,7 +51,7 @@
 			<arg name="start_external_sync" value="false"/>
 		</include>
 
-		<include file="$(find cob_bringup)/controllers/generic_controller.launch">
+		<include file="$(find cob_test_rigs)/launch/controllers/generic_controller.launch">
 			<arg name="robot" value="pg70"/>
 			<arg name="pkg_hardware_config" value="$(arg pkg_hardware_config)"/>
 			<arg name="component_name" value="pg70"/>

--- a/cob_test_rigs/launch/component.xml
+++ b/cob_test_rigs/launch/component.xml
@@ -23,7 +23,7 @@
 		<param name="robot_description" command="$(find xacro)/xacro --inorder '$(arg pkg_hardware_config)/robots/$(arg robot)/urdf/$(arg robot).urdf.xacro'"/>
 
 		<!-- start component -->
-		<include file="$(find cob_bringup)/drivers/canopen_402.launch">
+		<include file="$(find cob_test_rigs)/launch/drivers/canopen_402.launch">
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="pkg_hardware_config" value="$(arg pkg_hardware_config)"/>
 			<arg name="component_name" value="$(arg robot)"/>
@@ -33,7 +33,7 @@
 			<arg name="start_external_sync" value="$(arg start_external_sync)"/>
 		</include>
 
-		<include file="$(find cob_bringup)/controllers/generic_controller.launch">
+		<include file="$(find cob_test_rigs)/launch/controllers/generic_controller.launch">
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="pkg_hardware_config" value="$(arg pkg_hardware_config)"/>
 			<arg name="component_name" value="$(arg robot)"/>

--- a/cob_test_rigs/launch/controllers/generic_controller.launch
+++ b/cob_test_rigs/launch/controllers/generic_controller.launch
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<launch>
+
+	<arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
+	<arg name="pkg_hardware_config" default="$(find cob_test_rigs)"/>
+	<arg name="component_name"/>
+
+	<group ns="$(arg component_name)">
+
+		<!-- load controller configs -->
+		<rosparam command="load" file="$(arg pkg_hardware_config)/robots/$(arg robot)/config/$(arg component_name)_controller.yaml"/>
+		<!--rosparam command="load" file="$(arg pkg_hardware_config)/robots/$(arg robot)/config/$(arg component_name)_joint_limits.yaml"/-->
+
+		<!-- start_controllers -->
+		<node pkg="controller_manager" type="controller_manager" name="$(arg component_name)_controller_spawner" args="spawn joint_state_controller" respawn="false" output="screen"/>
+
+		<!-- control_mode_adapter -->
+		<node pkg="cob_control_mode_adapter" type="cob_control_mode_adapter_node" name="control_mode_adapter" cwd="node" respawn="false" output="screen"/>
+
+	</group>
+
+</launch>

--- a/cob_test_rigs/launch/drivers/canopen_402.launch
+++ b/cob_test_rigs/launch/drivers/canopen_402.launch
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<launch>
+
+	<arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
+	<arg name="pkg_hardware_config" default="$(find cob_test_rigs)"/>
+	<arg name="component_name"/>
+	<arg name="can_device"/>
+	<arg name="interval_ms"/>
+	<arg name="overflow" default="0"/>
+	<arg name="use_external_sync"/>
+	<arg name="start_external_sync"/>
+	<arg name="reset_errors_before_recover" default="false"/>
+	
+	<!-- start external sync node if requested -->
+	<node ns="$(arg component_name)" pkg="canopen_chain_node" type="canopen_sync_node" name="sync_$(arg can_device)" output="screen" if="$(arg start_external_sync)">
+		<rosparam subst_value="True">{bus: { device: $(arg can_device) }, sync: { interval_ms: $(arg interval_ms), overflow: $(arg overflow) } }</rosparam>
+	</node>
+
+	<!-- start canopen node -->
+	<node ns="$(arg component_name)" pkg="canopen_motor_node" type="canopen_motor_node" name="driver" output="screen">
+		<rosparam command="load" file="$(arg pkg_hardware_config)/robots/$(arg robot)/config/$(arg component_name)_driver.yaml"/>
+		<rosparam subst_value="True">{bus: { device: $(arg can_device) } }</rosparam>
+		<rosparam subst_value="True" if="$(arg use_external_sync)">{sync: { interval_ms: $(arg interval_ms), overflow: $(arg overflow) } }</rosparam>
+		<param name="bus/master_allocator" value="canopen::ExternalMaster::Allocator" if="$(arg use_external_sync)"/>
+		<param name="reset_errors_before_recover" value="$(arg reset_errors_before_recover)"/>
+	</node>
+
+</launch>

--- a/cob_test_rigs/launch/fdm.launch
+++ b/cob_test_rigs/launch/fdm.launch
@@ -17,7 +17,7 @@
 	<node pkg="robot_state_publisher" type="state_publisher" name="robot_state_publisher"/>
 
 	<!-- driver -->
-	<include file="$(find cob_bringup)/drivers/canopen_402.launch">
+	<include file="$(find cob_test_rigs)/launch/drivers/canopen_402.launch">
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="pkg_hardware_config" value="$(arg pkg_hardware_config)"/>
 		<arg name="component_name" value="$(arg robot)"/>

--- a/cob_test_rigs/launch/single_elmo.launch
+++ b/cob_test_rigs/launch/single_elmo.launch
@@ -16,7 +16,7 @@
 	<node pkg="robot_state_publisher" type="state_publisher" name="robot_state_publisher"/>
 
 	<!-- driver -->
-	<include file="$(find cob_bringup)/drivers/canopen_402.launch">
+	<include file="$(find cob_test_rigs)/launch/drivers/canopen_402.launch">
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="pkg_hardware_config" value="$(arg pkg_hardware_config)"/>
 		<arg name="component_name" value="single_elmo"/>

--- a/cob_test_rigs/launch/single_schunk.launch
+++ b/cob_test_rigs/launch/single_schunk.launch
@@ -16,7 +16,7 @@
 	<node pkg="robot_state_publisher" type="state_publisher" name="robot_state_publisher"/>
 
 	<!-- driver -->
-	<include file="$(find cob_bringup)/drivers/canopen_402.launch">
+	<include file="$(find cob_test_rigs)/launch/drivers/canopen_402.launch">
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="pkg_hardware_config" value="$(arg pkg_hardware_config)"/>
 		<arg name="component_name" value="single_schunk"/>

--- a/cob_test_rigs/package.xml
+++ b/cob_test_rigs/package.xml
@@ -11,7 +11,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <exec_depend>cob_bringup</exec_depend>
+  <exec_depend>canopen_chain_node</exec_depend>
+  <exec_depend>canopen_motor_node</exec_depend>
+  <exec_depend>cob_control_mode_adapter</exec_depend>
   <exec_depend>cob_description</exec_depend>
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>


### PR DESCRIPTION
depending on `cob_bringup` and `cob_bringup_sim` makes `mojin_ci` pass travis ci more difficult

 - `cob_bringup_test` is outdated anyway :point_right: not declaring dependency
 - `cob_test_rigs` should be usable for both mojin and research robots :point_right: copy-paste respective launch files to `cob_test_rigs` directly